### PR TITLE
Set the Video section to open when adding a Kaltura Media Resource

### DIFF
--- a/mod/kalvidres/mod_form.php
+++ b/mod/kalvidres/mod_form.php
@@ -129,6 +129,8 @@ class mod_kalvidres_mod_form extends moodleform_mod {
         $this->add_intro_editor(false);
 
         $mform->addElement('header', 'video', get_string('video_hdr', 'kalvidres'));
+	$mform->setExpanded('video',true);
+
         $this->add_video_definition($mform);
 
         $this->standard_coursemodule_elements();


### PR DESCRIPTION
By default, when you go and try to add a Kaltura Video Resource the video section is collapsed. It should be open, because that's the main reason for adding a video resource, to add a video.
