### PR TITLE
SUP-8116 change submission feedback even if no grade was provided

### DIFF
--- a/mod/kalvidassign/single_submission.php
+++ b/mod/kalvidassign/single_submission.php
@@ -141,17 +141,16 @@ if ($submissionform->is_cancelled()) {
 
             $submissionchanged = strcmp($submission->submissioncomment, $submitted_data->submissioncomment_editor['text']);
             if ($submission->grade == $submitted_data->xgrade && $submissionchanged) {
-
                 $updategrade = false;
-            } else {
-                $submission->grade              = $submitted_data->xgrade;
-                $submission->submissioncomment  = $submitted_data->submissioncomment_editor['text'];
-                $submission->format             = $submitted_data->submissioncomment_editor['format'];
-                $submission->timemarked         = time();
-                $submission->teacher            = $USER->id;
+            }
+            if ($submissionchanged || $updategrade) {
+                $submission->grade = $submitted_data->xgrade;
+                $submission->submissioncomment = $submitted_data->submissioncomment_editor['text'];
+                $submission->format = $submitted_data->submissioncomment_editor['format'];
+                $submission->timemarked = time();
+                $submission->teacher = $USER->id;
                 $DB->update_record('kalvidassign_submission', $submission);
             }
-
         } else {
 
             // Check for unchanged values


### PR DESCRIPTION
@muli 

Please review.

The issue is that we do not save the data if no grade was provided, i.e the teacher only gave feedback to the assignment but didn't fill a grade. I believe we still want to save the information regardless.

Let me know if this is OK, if so, I will create more PR for each dev branch. 
