### PR TITLE
Add composer.json to allow inclusion in composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,3 @@
+{
+    "name": "kaltura/moodle_plugin"
+}


### PR DESCRIPTION
This patch introduces a composer.json file to the plugin suite so that it can be included in composer based moodle builds.

A proof-of-concept for how this could be used is at https://github.com/dunlop-lello/moodle-composed and the related Moodle patch is at https://tracker.moodle.org/browse/MDL-54834
