### PR TITLE
Replace mcrypt_encrypt function

### DIFF
--- a/local/kaltura/API/KalturaClientBase.php
+++ b/local/kaltura/API/KalturaClientBase.php
@@ -887,11 +887,11 @@ class KalturaClientBase
 
 	protected static function aesEncrypt($key, $message)
 	{
-		return mcrypt_encrypt(
-			MCRYPT_RIJNDAEL_128,
-			substr(sha1($key, true), 0, 16),
+		return openssl_encrypt(
 			$message,
-			MCRYPT_MODE_CBC,
+			"AES-256-CBC",
+			substr(sha1($key, true), 0, 16),
+			0,
 			str_repeat("\0", 16)	// no need for an IV since we add a random string to the message anyway
 		);
 	}


### PR DESCRIPTION
Function "mcrypt_encrypt" has been deprecated as of PHP 7.1.0.
And, PHP 5.3.0 or later versions support a function "openssl_encrpt".
So that, I suggest replacing the function "mcrypt_encrypt" with the function "openssl_encrypt".