### PR TITLE
Remove redundant button css classes

### DIFF
--- a/mod/kalvidres/mod_form.php
+++ b/mod/kalvidres/mod_form.php
@@ -154,9 +154,9 @@ class mod_kalvidres_mod_form extends moodleform_mod {
 
         $videogroup = array();
         if ($addinstance) {
-            $videogroup[] =& $mform->createElement('button', $this->addvideobutton, get_string('add_video', 'kalvidres'), array('class' => 'btn btn-secondary'));
+            $videogroup[] =& $mform->createElement('button', $this->addvideobutton, get_string('add_video', 'kalvidres'));
         } else {
-            $videogroup[] =& $mform->createElement('button', $this->addvideobutton, get_string('replace_video', 'kalvidres'), array('class' => 'btn btn-secondary'));
+            $videogroup[] =& $mform->createElement('button', $this->addvideobutton, get_string('replace_video', 'kalvidres'));
         }
 
         $mform->addGroup($videogroup, 'video_group', '&nbsp;', '&nbsp;', false);


### PR DESCRIPTION
Hi @yusitnikov 

These CSS classes are not needed and can be safely deleted. The button itself has already these styling. So no need for the form.

![image](https://user-images.githubusercontent.com/9467708/70895462-4ac09000-1fef-11ea-9a44-713a9642b8a7.png)

Greets,
Adrian