### PR TITLE
Add setting to enable fontawesome icons for navigation drawer

### DIFF
--- a/local/kaltura/lang/en/local_kaltura.php
+++ b/local/kaltura/lang/en/local_kaltura.php
@@ -90,3 +90,6 @@ $string['privacy:metadata:editor'] = 'The editor of the user accessing the LTI C
 $string['privacy:metadata:module'] = 'The name of the module the user is accessing the LTI Consumer from';
 $string['privacy:metadata:source'] = 'The source URL of the media entry of the user accessing the LTI Consumer';
 $string['privacy:metadata:custompublishdata'] = 'The courses the user is enrolled in and the LTI roles the user has in the course';
+$string['kaltura_additional_hdr'] = 'Additional configuration';
+$string['icons_fontawesome'] = 'Enable fontawesome icons in navigation drawer';
+$string['icons_fontawesome_desc'] = 'If enabled Moodle will use in the navigation drawer fontawesome icons instead of the pix.';

--- a/local/kaltura/settings.php
+++ b/local/kaltura/settings.php
@@ -96,4 +96,13 @@ if ($hassiteconfig) {
         $adminsetting->plugin = KALTURA_PLUGIN_NAME;
         $settings->add($adminsetting);
     }
+
+    $adminsetting = new admin_setting_heading('kaltura_additional_heading', get_string('kaltura_additional_hdr', 'local_kaltura'),'');
+    $adminsetting->plugin = KALTURA_PLUGIN_NAME;
+    $settings->add($adminsetting);
+
+    $adminsetting = new admin_setting_configcheckbox('enable_fontawesome', get_string('icons_fontawesome', 'local_kaltura'),
+            get_string('icons_fontawesome_desc','local_kaltura'), 0);
+    $adminsetting->plugin = KALTURA_PLUGIN_NAME;
+    $settings->add($adminsetting);
 }

--- a/local/kalturamediagallery/lib.php
+++ b/local/kalturamediagallery/lib.php
@@ -119,5 +119,9 @@ function isNodeNotEmpty(navigation_node $node) {
 }
 
 function getMediaGalleryIcon() {
-    return new pix_icon('media-gallery', '', 'local_kalturamediagallery');
+    if (get_config('local_kaltura', 'enable_fontawesome')) {
+        return new pix_icon('e/insert_edit_video', '');
+    } else {
+        return new pix_icon('media-gallery', '', 'local_kalturamediagallery');
+    }
 }

--- a/local/mymedia/lib.php
+++ b/local/mymedia/lib.php
@@ -54,7 +54,15 @@ function local_mymedia_extend_navigation($navigation) {
         return;
     }
     $mymedia = get_string('nav_mymedia', 'local_mymedia');
-    $icon = new pix_icon('my-media', '', 'local_mymedia');
+    $icon = getMyMediaIcon();
     $nodemymedia = $nodehome->add($mymedia, new moodle_url('/local/mymedia/mymedia.php'), navigation_node::NODETYPE_LEAF, $mymedia, 'mymedia', $icon);
     $nodemymedia->showinflatnavigation = true;
+}
+
+function getMyMediaIcon() {
+    if (get_config('local_kaltura', 'enable_fontawesome')) {
+        return new pix_icon('t/go', '');
+    } else {
+        return new pix_icon('my-media', '', 'local_mymedia');
+    }
 }


### PR DESCRIPTION
Hi @muli 

Would be cool if you can add this additional setting. So users can choose which icons they want to use. Moodle core uses fontawesome in the navigation drawer and you're using images.

Greets,
Adrian