### PR TITLE
Remove double button styling fixes #271.

### DIFF
--- a/mod/kalvidres/mod_form.php
+++ b/mod/kalvidres/mod_form.php
@@ -154,9 +154,9 @@ class mod_kalvidres_mod_form extends moodleform_mod {
 
         $videogroup = array();
         if ($addinstance) {
-            $videogroup[] =& $mform->createElement('button', $this->addvideobutton, get_string('add_video', 'kalvidres'), array('class' => 'btn btn-secondary'));
+            $videogroup[] =& $mform->createElement('button', $this->addvideobutton, get_string('add_video', 'kalvidres'));
         } else {
-            $videogroup[] =& $mform->createElement('button', $this->addvideobutton, get_string('replace_video', 'kalvidres'), array('class' => 'btn btn-secondary'));
+            $videogroup[] =& $mform->createElement('button', $this->addvideobutton, get_string('replace_video', 'kalvidres'));
         }
 
         $mform->addGroup($videogroup, 'video_group', '&nbsp;', '&nbsp;', false);


### PR DESCRIPTION
Doesn't affect 3.7 and 3.8 version of the plugin.