### PR TITLE
Fix #308

### DIFF
--- a/local/kalturamediagallery/lib.php
+++ b/local/kalturamediagallery/lib.php
@@ -114,7 +114,7 @@ function local_kalturamediagallery_extend_navigation_course(navigation_node $par
     $parent->add($name, $url, navigation_node::NODETYPE_LEAF, $name, 'kalturamediagallery-settings', getMediaGalleryIcon());
 }
 
-function isNodeNotEmpty(navigation_node $node) {
+function isNodeNotEmpty($node) {
     return $node !== false && $node->has_children();
 }
 


### PR DESCRIPTION
Fix 'Argument 1 passed to isNodeNotEmpty() must be an instance of navigation_node, boolean given' - #308