### PR TITLE
Add settings to filter on additional URIs

### DIFF
--- a/filter/kaltura/filter.php
+++ b/filter/kaltura/filter.php
@@ -127,8 +127,15 @@ class filter_kaltura extends moodle_text_filter {
         $kafuri = rtrim($kafuri, '/');
         $kafuri = str_replace(array('http://', 'https://', '.', '/'), array('https?://', 'https?://', '\.', '\/'), $kafuri);
 
-        $search = $search = '/<a\s[^>]*href="(((https?:\/\/'.KALTURA_URI_TOKEN.')|('.$kafuri.')))\/browseandembed\/index\/media\/entryid\/([\d]+_[a-z0-9]+)(\/([a-zA-Z0-9]+\/[a-zA-Z0-9]+\/)*)"[^>]*>([^>]*)<\/a>/is';
+        $kafurialt = 'http://appstate-moodle.kaf.kaltura.com';
+        $kafurialt = rtrim($kafurialt, '/');
+        $kafurialt = str_replace(array('http://', 'https://', '.', '/'), array('https?://', 'https?://', '\.', '\/'), $kafurialt);
+        
+        //$search = $search = '/<a\s[^>]*href="(((https?:\/\/'.KALTURA_URI_TOKEN.')|('.$kafuri.')))\/browseandembed\/index\/media\/entryid\/([\d]+_[a-z0-9]+)(\/([a-zA-Z0-9]+\/[a-zA-Z0-9]+\/)*)"[^>]*>([^>]*)<\/a>/is';
+        $search = $search = '/<a\s[^>]*href="(((https?:\/\/'.KALTURA_URI_TOKEN.')|('.$kafuri.')|('.$kafurialt.')))\/browseandembed\/index\/media\/entryid\/([\d]+_[a-z0-9]+)(\/([a-zA-Z0-9]+\/[a-zA-Z0-9]+\/)*)"[^>]*>([^>]*)<\/a>/is';
         $newtext = preg_replace_callback($search, 'filter_kaltura_callback', $newtext);
+        // callback is not getting source because of number of parts of link
+        // change config back to kaltura url and see what happens
 
         if (empty($newtext) || $newtext === $text) {
             // Error or not filtered.
@@ -151,9 +158,9 @@ function filter_kaltura_callback($link) {
     $source = '';
 
     // Convert KAF URI anchor tags into iframe markup.
-    if (9 == count($link)) {
+    if (10 == count($link)) {
         // Get the height and width of the iframe.
-        $properties = explode('||', $link[8]);
+        $properties = explode('||', $link[9]);
 
         $width = $properties[2];
         $height = $properties[3];
@@ -162,7 +169,7 @@ function filter_kaltura_callback($link) {
             return $link[0];
         }
 
-        $source = filter_kaltura::$kafuri . '/browseandembed/index/media/entryid/' . $link[5] . $link[6];
+        $source = filter_kaltura::$kafuri . '/browseandembed/index/media/entryid/' . $link[6] . $link[7];
     }
 
     // Convert v3 anchor tags into iframe markup.

--- a/filter/kaltura/filter.php
+++ b/filter/kaltura/filter.php
@@ -127,15 +127,31 @@ class filter_kaltura extends moodle_text_filter {
         $kafuri = rtrim($kafuri, '/');
         $kafuri = str_replace(array('http://', 'https://', '.', '/'), array('https?://', 'https?://', '\.', '\/'), $kafuri);
 
-        $kafurialt = 'http://appstate-moodle.kaf.kaltura.com';
-        $kafurialt = rtrim($kafurialt, '/');
-        $kafurialt = str_replace(array('http://', 'https://', '.', '/'), array('https?://', 'https?://', '\.', '\/'), $kafurialt);
-        
-        //$search = $search = '/<a\s[^>]*href="(((https?:\/\/'.KALTURA_URI_TOKEN.')|('.$kafuri.')))\/browseandembed\/index\/media\/entryid\/([\d]+_[a-z0-9]+)(\/([a-zA-Z0-9]+\/[a-zA-Z0-9]+\/)*)"[^>]*>([^>]*)<\/a>/is';
-        $search = $search = '/<a\s[^>]*href="(((https?:\/\/'.KALTURA_URI_TOKEN.')|('.$kafuri.')|('.$kafurialt.')))\/browseandembed\/index\/media\/entryid\/([\d]+_[a-z0-9]+)(\/([a-zA-Z0-9]+\/[a-zA-Z0-9]+\/)*)"[^>]*>([^>]*)<\/a>/is';
+        $search = $search = '/<a\s[^>]*href="(((https?:\/\/'.KALTURA_URI_TOKEN.')|('.$kafuri.')))\/browseandembed\/index\/media\/entryid\/([\d]+_[a-z0-9]+)(\/([a-zA-Z0-9]+\/[a-zA-Z0-9]+\/)*)"[^>]*>([^>]*)<\/a>/is';
+
+        if (!empty($CFG->filter_kaltura_uris)) {
+            $altkafuriconfig = $CFG->filter_kaltura_uris;
+            $altkafuris = explode(PHP_EOL, $altkafuriconfig);
+
+            $search = $search = '/<a\s[^>]*href="(((https?:\/\/'.KALTURA_URI_TOKEN.')|('.$kafuri.')';
+
+            foreach ($altkafuris as $altkafuri) {
+                $altkafuri = rtrim($altkafuri);
+                if ($altkafuri != '') {
+                    // If a https url is needed for kaf_uri it should be entered into the kaf_uri setting as https://.
+                    if (!preg_match('#^https?://#', $altkafuri)) {
+                        $altkafuri = 'http://' . $altkafuri;
+                    }
+
+                    $altkafuri = str_replace(array('http://', 'https://', '.', '/'), array('https?://', 'https?://', '\.', '\/'), $altkafuri);
+                    $search .= '|('.$altkafuri.')';
+                }
+            }
+
+            $search .= '))\/browseandembed\/index\/media\/entryid\/([\d]+_[a-z0-9]+)(\/([a-zA-Z0-9]+\/[a-zA-Z0-9]+\/)*)"[^>]*>([^>]*)<\/a>/is';
+        }
+
         $newtext = preg_replace_callback($search, 'filter_kaltura_callback', $newtext);
-        // callback is not getting source because of number of parts of link
-        // change config back to kaltura url and see what happens
 
         if (empty($newtext) || $newtext === $text) {
             // Error or not filtered.
@@ -158,9 +174,10 @@ function filter_kaltura_callback($link) {
     $source = '';
 
     // Convert KAF URI anchor tags into iframe markup.
-    if (10 == count($link)) {
+    $count = count($link);
+    if ($count > 7) {
         // Get the height and width of the iframe.
-        $properties = explode('||', $link[9]);
+        $properties = explode('||', $link[$count - 1]);
 
         $width = $properties[2];
         $height = $properties[3];
@@ -169,7 +186,7 @@ function filter_kaltura_callback($link) {
             return $link[0];
         }
 
-        $source = filter_kaltura::$kafuri . '/browseandembed/index/media/entryid/' . $link[6] . $link[7];
+        $source = filter_kaltura::$kafuri . '/browseandembed/index/media/entryid/' . $link[$count - 4] . $link[$count - 3];
     }
 
     // Convert v3 anchor tags into iframe markup.

--- a/filter/kaltura/filtersettings.php
+++ b/filter/kaltura/filtersettings.php
@@ -27,4 +27,8 @@ defined('MOODLE_INTERNAL') || die;
 
 if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('filter_kaltura_enable', get_string('enable', 'filter_kaltura'), get_string('enable_help', 'filter_kaltura'), 1));
+
+    $settings->add(new admin_setting_configtextarea('filter_kaltura_uris',
+        get_string('uris', 'filter_kaltura'),
+        get_string('uris_help', 'filter_kaltura'), ''));
 }

--- a/filter/kaltura/lang/en/filter_kaltura.php
+++ b/filter/kaltura/lang/en/filter_kaltura.php
@@ -26,5 +26,7 @@
 $string['filtername'] = 'Kaltura Media';
 $string['enable'] = 'Embed Kaltura Video Links';
 $string['enable_help'] = 'Convert Kaltura video links to embed code';
+$string['uris'] = 'Alternate KAF URIs';
+$string['uris_help'] = 'Enter alternate KAF URIs to filter, one per line';
 $string['unable'] = 'Unable to convert video at this time';
 $string['privacy:metadata'] = 'The Kaltura Media filter does not store any personal data.';


### PR DESCRIPTION
When changing from the Kaltura KAF URI to a custom one to address the issue of third-party cookie blocking, existing embedded media (with the Kaltura KAF URI) are no longer filtered to convert links to players. This patch adds a config in the filter settings where users can enter alternate KAF URIs to be included for filtering/conversion.