### PR TITLE
Add settings to filter on additional URIs

### DIFF
--- a/filter/kaltura/filtersettings.php
+++ b/filter/kaltura/filtersettings.php
@@ -27,4 +27,8 @@ defined('MOODLE_INTERNAL') || die;
 
 if ($ADMIN->fulltree) {
     $settings->add(new admin_setting_configcheckbox('filter_kaltura_enable', get_string('enable', 'filter_kaltura'), get_string('enable_help', 'filter_kaltura'), 1));
+
+    $settings->add(new admin_setting_configtextarea('filter_kaltura_uris',
+        get_string('uris', 'filter_kaltura'),
+        get_string('uris_help', 'filter_kaltura'), ''));
 }

--- a/filter/kaltura/lang/en/filter_kaltura.php
+++ b/filter/kaltura/lang/en/filter_kaltura.php
@@ -26,5 +26,7 @@
 $string['filtername'] = 'Kaltura Media';
 $string['enable'] = 'Embed Kaltura Video Links';
 $string['enable_help'] = 'Convert Kaltura video links to embed code';
+$string['uris'] = 'Alternate KAF URIs';
+$string['uris_help'] = 'Enter alternate KAF URIs to filter, one per line';
 $string['unable'] = 'Unable to convert video at this time';
 $string['privacy:metadata'] = 'The Kaltura Media filter does not store any personal data.';


### PR DESCRIPTION
When changing from the Kaltura KAF URI to a custom one to address the issue of third-party cookie blocking, existing embedded media (with the Kaltura KAF URI) are no longer filtered to convert links to players. This patch adds a config in the filter settings where users can enter alternate KAF URIs to be included for filtering/conversion (3.10 branch).