### PR TITLE
Add Mobile App support to kalvidres

### DIFF
--- a/mod/kalvidres/classes/output/mobile.php
+++ b/mod/kalvidres/classes/output/mobile.php
@@ -1,0 +1,118 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Kaltura local library of functions.
+ *
+ * @package    local_kaltura
+ * @author     Remote-Learner.net Inc
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  (C) 2014 Remote Learner.net Inc http://www.remote-learner.net
+ */
+
+namespace mod_kalvidres\output;
+defined('MOODLE_INTERNAL') || die();
+
+require_once("$CFG->dirroot/lib/externallib.php");
+require_once("$CFG->dirroot/local/kaltura/locallib.php");
+
+class mobile {
+
+    public static function mobile_view_activity($args) {
+        global $DB, $OUTPUT;
+
+        $args = (object) $args;
+
+        $cmid = $args->cmid;
+
+        // Capabilities check.
+        $cm = get_coursemodule_from_id('kalvidres', $cmid);
+        $context = \context_module::instance($cm->id);
+        require_login($cm->course, false, $cm, true, true);
+        require_capability('mod/kalvidres:view', $context);
+        $course = get_course($cm->course);
+
+        // Set some variables we are going to be using.
+        $kalvidres = $DB->get_record('kalvidres', ['id' => $cm->instance], '*', MUST_EXIST);
+        $kalvidres->name = format_string($kalvidres->name);
+        list($kalvidres->intro, $kalvidres->introformat) = external_format_text($kalvidres->intro,
+                $kalvidres->introformat, $context->id, 'mod_kalvidres', 'intro');
+
+        $token = required_param('wstoken', PARAM_RAW);
+
+        // Update log and set completion.
+        $event = \mod_kalvidres\event\video_resource_viewed::create(array(
+                'objectid' => $kalvidres->id,
+                'context' => $context
+        ));
+        $event->trigger();
+        $completion = new \completion_info($course);
+        $completion->set_module_viewed($cm);
+
+        $ltiparams = [
+            'courseid' => $cm->course,
+            'cmid' => $cm->id,
+            'height' => $kalvidres->height,
+            'width' => $kalvidres->width,
+            'withblocks' => 0,
+            // Force to known default player (will be swapped to configured url in mobile_launch).
+            'source' => 'https://' . KALTURA_URI_TOKEN . '/browseandembed/index/media/entryid/' . $kalvidres->entry_id,
+            'token' => $token,
+        ];
+        $ltiurl = new \moodle_url('/mod/kalvidres/mobile_launch.php', $ltiparams);
+
+        $data = [
+            'kalvidres' => $kalvidres,
+            'iframe' => self::display_iframe($ltiurl->out(false)),
+            'cmid' => $cm->id,
+        ];
+
+        return [
+            'templates'  => [
+                [
+                    'id' => 'main',
+                    'html' => $OUTPUT->render_from_template('mod_kalvidres/mobile_view_activity', $data),
+                ],
+            ],
+            'javascript' => '',
+            'otherdata' => '',
+        ];
+
+    }
+
+    /**
+     * This function displays the iframe markup.
+     * @param string $url iframe src url
+     * @return string HTML markup.
+     */
+    public static function display_iframe($url) {
+        $attr = [
+            'id' => 'contentframe',
+            'class' => 'kaltura-player-iframe',
+            'src' => $url,
+            'allowfullscreen' => 'true',
+            'allow' => 'autoplay *; fullscreen *; encrypted-media *; camera *; microphone *;',
+            'style' => 'left:0; top:0; position:absolute; border:none; width:100%; height:100%;',
+        ];
+
+        $iframe = \html_writer::tag('iframe', '', $attr);
+        $iframecontainer = \html_writer::tag('div', $iframe, array(
+            'class' => 'kaltura-player-container'
+        ));
+
+        return $iframecontainer;
+    }
+}

--- a/mod/kalvidres/db/access.php
+++ b/mod/kalvidres/db/access.php
@@ -32,4 +32,15 @@ $capabilities = array(
         ),
         'clonepermissionsfrom' => 'moodle/course:manageactivities'
     ),
+    'mod/kalvidres:view' => array(
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_MODULE,
+        'archetypes' => array(
+            'guest' => CAP_ALLOW,
+            'student' => CAP_ALLOW,
+            'teacher' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'manager' => CAP_ALLOW
+        )
+    ),
  );

--- a/mod/kalvidres/db/mobile.php
+++ b/mod/kalvidres/db/mobile.php
@@ -1,0 +1,43 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Defines mobile handlers.
+ *
+ * @package   mod_kalvidres
+ * @copyright 2020 Bas Brands <bas@moodle.com>
+ * @license   http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+
+defined('MOODLE_INTERNAL') || die();
+
+$addons = [
+    'mod_kalvidres' => [ // Plugin identifier.
+        'handlers' => [ // Different places where the plugin will display content.
+            'viewkaltura' => [ // Handler unique name.
+                'displaydata' => [
+                    'icon' => $CFG->wwwroot . '/mod/kalvidres/pix/icon.svg',
+                    'class' => 'core-course-module-kalvidres-handler',
+                ],
+                'delegate' => 'CoreCourseModuleDelegate', // Delegate (where to display the link to the plugin).
+                'method' => 'mobile_view_activity', // Main function in \mod_kalvides\output\mobile.
+            ]
+        ],
+        'lang' => [ // Language strings that are used in all the handlers.
+            ['pluginname', 'kalvidres'],
+        ]
+    ]
+];

--- a/mod/kalvidres/lang/en/kalvidres.php
+++ b/mod/kalvidres/lang/en/kalvidres.php
@@ -35,5 +35,6 @@ $string['invalid_launch_parameters'] = 'Invalid launch parameters';
 $string['invalid_source_parameter'] = 'Invalid source parameter';
 $string['replace_video'] = 'Replace media';
 $string['kalvidres:addinstance'] = 'Add a Kaltura Video Resource';
+$string['kalvidres:view'] = 'View kalvidres activity';
 $string['eventvideo_resource_viewed'] = 'Video resource viewed';
 $string['privacy:metadata'] = 'Kaltura video resource plugin does not store any personal data.';

--- a/mod/kalvidres/lib.php
+++ b/mod/kalvidres/lib.php
@@ -168,7 +168,7 @@ function kalvidres_supports($feature) {
         case FEATURE_MOD_INTRO:
             return true;
         case FEATURE_COMPLETION_TRACKS_VIEWS:
-            return false;
+            return true;
         case FEATURE_GRADE_HAS_GRADE:
             return false;
         case FEATURE_GRADE_OUTCOMES:
@@ -178,4 +178,13 @@ function kalvidres_supports($feature) {
         default:
             return null;
     }
+}
+
+/**
+ * This function is used by the reset_course_userdata function in moodlelib.
+ * @param $data the data submitted from the reset course.
+ * @return array status array
+ */
+function kalvidres_reset_userdata($data) {
+    return array();
 }

--- a/mod/kalvidres/mobile_launch.php
+++ b/mod/kalvidres/mobile_launch.php
@@ -1,0 +1,72 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+/**
+ * Kaltura video resource LTI launch page.
+ *
+ * @package    mod_kalvidres
+ * @author     Remote-Learner.net Inc
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ * @copyright  (C) 2014 Remote Learner.net Inc http://www.remote-learner.net
+ */
+
+require_once(dirname(dirname(dirname(__FILE__))) . '/config.php');
+require_once($CFG->dirroot . '/webservice/lib.php');
+require_once($CFG->dirroot . '/local/kaltura/locallib.php');
+
+$token = required_param('token', PARAM_ALPHANUM);
+$webservicelib = new webservice();
+$webservicelib->authenticate_user($token);
+
+$courseid = required_param('courseid', PARAM_INT);
+$cmid = required_param('cmid', PARAM_INT);
+$height = required_param('height', PARAM_INT);
+$width = required_param('width', PARAM_INT);
+$withblocks = optional_param('withblocks', 0, PARAM_INT);
+$source = optional_param('source', '', PARAM_URL);
+
+$context = context_course::instance($courseid);
+
+// Capabilities check.
+$cm = get_coursemodule_from_id('kalvidres', $cmid);
+require_login($cm->course, false, $cm, true, false);
+require_capability('mod/kalvidres:view', $context);
+
+$launch = array();
+$launch['id'] = 1;
+$launch['cmid'] = $cmid;
+$launch['title'] = 'Kaltura video resource';
+$launch['module'] = KAF_BROWSE_EMBED_MODULE;
+$launch['course'] = get_course($courseid);
+$launch['width'] = $width;
+$launch['height'] = $height;
+$launch['custom_publishdata'] = '';
+
+$source = local_kaltura_add_kaf_uri_token($source);
+
+if (false === local_kaltura_url_contains_configured_hostname($source) && !empty($source)) {
+    echo get_string('invalid_source_parameter', 'mod_kalvidres');
+    die;
+} else {
+    $launch['source'] = urldecode($source);
+}
+
+if (local_kaltura_validate_browseembed_required_params($launch)) {
+    $content = local_kaltura_request_lti_launch($launch, $withblocks);
+    echo $content;
+} else {
+    echo get_string('invalid_launch_parameters', 'mod_kalvidres');
+}

--- a/mod/kalvidres/templates/mobile_view_activity.mustache
+++ b/mod/kalvidres/templates/mobile_view_activity.mustache
@@ -1,0 +1,22 @@
+{{=<% %>=}}
+<div>
+    <core-course-module-description description="<% kalvidres.intro %>" component="mod_kalvidres" componentId="<% cmid %>"></core-course-module-description>
+
+    <ion-card>
+        <style>
+            .col-md-6 {
+                flex: 0 0 50%;
+                max-width: 50%;
+                padding: 0 15px;
+            }
+        </style>
+
+        <ion-item>
+            <div style="max-width:100%;">
+                <div style="overflow:hidden; padding-bottom:calc(56.25% + 30px); position:relative; height:0;">
+                    <%{ iframe }%>
+                </div>
+            </div>
+        </ion-item>
+    </ion-card>
+</div>

--- a/mod/kalvidres/version.php
+++ b/mod/kalvidres/version.php
@@ -25,7 +25,7 @@ if (!defined('MOODLE_INTERNAL')) {
     die('Direct access to this script is forbidden.');
 }
 
-$plugin->version = 20201215310;
+$plugin->version = 2021041300;
 $plugin->component  = 'mod_kalvidres';
 $plugin->release    = 'Kaltura release 4.2.9';
 $plugin->requires = 2018120300;


### PR DESCRIPTION
This change adds Moodle Mobile App support to the kalvidres plugin.
(Online support only - I haven't added an offline fallback message or considered the ability to download and play assets locally)

To support this a new 'view' capability has also been added.

This code has been checked on Moodle 3.10+ only.

Thanks to https://github.com/arup-group for providing their own app implementation code that was used as a base for this work.