### PR TITLE
Add specific capabilities

### DIFF
--- a/filter/kaltura/lang/en/filter_kaltura.php
+++ b/filter/kaltura/lang/en/filter_kaltura.php
@@ -24,9 +24,12 @@
  */
 
 $string['filtername'] = 'Kaltura Media';
+$string['pluginname'] = 'Kaltura Media Filter';
 $string['enable'] = 'Embed Kaltura Video Links';
 $string['enable_help'] = 'Convert Kaltura video links to embed code';
-$string['uris'] = 'Alternate KAF URIs';
-$string['uris_help'] = 'Enter alternate KAF URIs to filter, one per line';
+$string['moodle_trace_log'] = 'Enable moodle trace logging';
+$string['moodle_trace_log_desc'] = 'If enabled, all requests and responses to and from Kaltura are logged into Moodle logging system.';
+$string['kalturamediaviewed'] = 'Kaltura media viewed';
 $string['unable'] = 'Unable to convert video at this time';
 $string['privacy:metadata'] = 'The Kaltura Media filter does not store any personal data.';
+$string['kaltura:view'] = 'Permission for user can filter Embed Kaltura Video Links';

--- a/filter/kaltura/lti_launch.php
+++ b/filter/kaltura/lti_launch.php
@@ -35,6 +35,7 @@ $height = required_param('height', PARAM_INT);
 $width = required_param('width', PARAM_INT);
 $withblocks = optional_param('withblocks', 0, PARAM_INT);
 $source = optional_param('source', '', PARAM_URL);
+$embedcontextid = optional_param('embedcontextid', 0, PARAM_INT);
 
 // If a course id of zero is passed, then we must be in the system context.
 if (0 != $courseid) {
@@ -47,8 +48,8 @@ if (0 != $courseid) {
 if ($context instanceof context_course) {
     $course = get_course($courseid);
 
-    // Check if the user has the capability to view comments in Moodle.
-    if (!has_capability('moodle/comment:view', $context)) {
+    // Check if the user has the capability to view kaltura media.
+    if (!has_capability('filter/kaltura:view', $context)) {
         echo get_string('nocapabilitytousethisservice', 'error');
         die();
     }

--- a/local/kaltura/db/access.php
+++ b/local/kaltura/db/access.php
@@ -36,4 +36,27 @@ $capabilities = array(
             'manager' => CAP_ALLOW,
         )
     ),
+    'local/kaltura:lti_admin_role' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'manager' => CAP_ALLOW,
+        ]
+    ],
+    'local/kaltura:lti_instructor_role' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'editingteacher' => CAP_ALLOW,
+        ],
+        'clonepermissionsfrom' => 'moodle/course:manageactivities'
+    ],
+    'local/kaltura:lti_learner_role' => [
+        'captype' => 'read',
+        'contextlevel' => CONTEXT_COURSE,
+        'archetypes' => [
+            'teacher' => CAP_ALLOW,
+            'student' => CAP_ALLOW,
+        ]
+    ],
 );

--- a/local/kaltura/db/upgrade.php
+++ b/local/kaltura/db/upgrade.php
@@ -73,6 +73,5 @@ function xmldb_local_kaltura_upgrade($oldversion) {
         // Kaltura savepoint reached.
         upgrade_plugin_savepoint(true, 2016120130, 'local', 'kaltura');
     }
-
     return true;
 }

--- a/local/kaltura/lang/en/local_kaltura.php
+++ b/local/kaltura/lang/en/local_kaltura.php
@@ -90,3 +90,6 @@ $string['privacy:metadata:editor'] = 'The editor of the user accessing the LTI C
 $string['privacy:metadata:module'] = 'The name of the module the user is accessing the LTI Consumer from';
 $string['privacy:metadata:source'] = 'The source URL of the media entry of the user accessing the LTI Consumer';
 $string['privacy:metadata:custompublishdata'] = 'The courses the user is enrolled in and the LTI roles the user has in the course';
+$string['kaltura:lti_admin_role'] = 'Admin permission for Kaltura LTI intergration';
+$string['kaltura:lti_instructor_role'] = 'Instructor permission for Kaltura LTI intergration';
+$string['kaltura:lti_learner_role'] = 'Learner permission for Kaltura LTI intergration';

--- a/local/kaltura/locallib.php
+++ b/local/kaltura/locallib.php
@@ -465,42 +465,54 @@ function local_kaltura_format_uri($uri) {
 /**
  * This function creates a JSON string of the courses the user is enrolled in and the LTI roles the user has in the course.
  * The JSON string is cached in the user's session global for efficiency purposes.
+ * @throws \coding_exception
  * @return string A JSON data structure outlining the user's LTI roles in all of their enroled courses.
  */
 function local_kaltura_get_kaf_publishing_data() {
-    global $USER, $SITE;
+    global $USER, $SITE, $COURSE;
 
-    $role = is_siteadmin($USER->id) ? KALTURA_LTI_ADMIN_ROLE : KALTURA_LTI_INSTRUCTOR_ROLE;
     $json = new stdClass();
     $json->courses = array();
-    $hascap = false;
+    $courses = [];
 
-    // If the user is not an admin then retrieve all of the user's enroled courses.
-    if (KALTURA_LTI_ADMIN_ROLE != $role) {
-        $courses = enrol_get_users_courses($USER->id, true, 'id,fullname,shortname', 'fullname ASC');
-    } else {
-        // Calling refactored code that allows for a limit on the number of courses returned.
-        $courses = local_kaltura_get_user_capability_course('moodle/course:manageactivities', $USER->id, true, 'id,fullname,shortname', 'fullname ASC');
+    $capabilities = [
+            KALTURA_LTI_ADMIN_ROLE => 'local/kaltura:lti_admin_role',
+            KALTURA_LTI_INSTRUCTOR_ROLE => 'local/kaltura:lti_instructor_role',
+            KALTURA_LTI_LEARNER_ROLE => 'local/kaltura:lti_learner_role',
+    ];
+    foreach ($capabilities as $capability) {
+        if ($coursebycapability = get_user_capability_course($capability, $USER->id, false, 'id,fullname,shortname,timemodified', 'id DESC,timemodified DESC', 200)) {
+            $courses = array_merge($courses, $coursebycapability);
+        }
     }
+    $courses = array_unique($courses, SORT_REGULAR);
+    usort($courses, function($a, $b) {
+        return $a->id < $b->id ? 1 : -1;
+    });
+    $courses = array_splice($courses, 0, 200);
+    array_unshift($courses, $COURSE);
 
     foreach ($courses as $course) {
         if ($course->id === $SITE->id) {
             // Don't want to include the site id in this list
             continue;
         }
-
-        if (KALTURA_LTI_ADMIN_ROLE != $role) {
-            // Check if the user has the manage capability in the course.
-            $hascap = has_capability('moodle/course:manageactivities', context_course::instance($course->id), $USER->id, false);
-            $role = $hascap ? KALTURA_LTI_INSTRUCTOR_ROLE : KALTURA_LTI_LEARNER_ROLE;
+        $courserole = '';
+        foreach ($capabilities as $role => $capability) {
+            if (has_capability($capability, context_course::instance($course->id), $USER->id, false)) {
+                $courserole = $role;
+                break;
+            }
         }
-
+        if (empty($courserole)) {
+            continue;
+        }
         // The properties must be nameed "courseId", "courseName" and "roles".
         $data = new stdClass();
         $data->courseId = $course->id;
         $data->courseName = $course->fullname;
         $data->courseShortName = $course->shortname;
-        $data->roles = $role;
+        $data->roles = $courserole;
         $json->courses[$course->id] = $data;
     }
 

--- a/local/kaltura/tests/locallib_test.php
+++ b/local/kaltura/tests/locallib_test.php
@@ -977,7 +977,7 @@ class local_kaltura_locallib_testcase extends advanced_testcase {
         );
         $coursetwo = $this->getDataGenerator()->create_course($coursedata);
 
-        $this->getDataGenerator()->enrol_user($user->id, $coursetwo->id, $role['student']->id, 'manual');
+        $this->getDataGenerator()->enrol_user($user->id, $coursetwo->id, $role['teacher']->id, 'manual');
 
         $coursedata = array(
             'fullname' => 'Test 3',
@@ -998,9 +998,9 @@ class local_kaltura_locallib_testcase extends advanced_testcase {
 
         $result = local_kaltura_get_kaf_publishing_data();
 
-        $json = '{"courses":[{"courseId":"'.$courseone->id.'","courseName":"'.$courseone->fullname.'","courseShortName":"'.$courseone->shortname.'","roles":"Instructor"}';
+        $json = '{"courses":[{"courseId":"'.$coursefour->id.'","courseName":"'.$coursefour->fullname.'","courseShortName":"'.$coursefour->shortname.'","roles":"Instructor"}';
         $json .= ',{"courseId":"'.$coursetwo->id.'","courseName":"'.$coursetwo->fullname.'","courseShortName":"'.$coursetwo->shortname.'","roles":"Learner"}';
-        $json .= ',{"courseId":"'.$coursefour->id.'","courseName":"'.$coursefour->fullname.'","courseShortName":"'.$coursefour->shortname.'","roles":"Instructor"}]}';
+        $json .= ',{"courseId":"'.$courseone->id.'","courseName":"'.$courseone->fullname.'","courseShortName":"'.$courseone->shortname.'","roles":"Instructor"}]}';
 
         $this->assertEquals(base64_encode($json), $result);
     }
@@ -1041,10 +1041,7 @@ class local_kaltura_locallib_testcase extends advanced_testcase {
 
         $result = local_kaltura_get_kaf_publishing_data();
 
-        $json = '{"courses":[{"courseId":"'.$courseone->id.'","courseName":"'.$courseone->fullname.'","courseShortName":"'.$courseone->shortname.'","roles":"urn:lti:sysrole:ims\/lis\/Administrator"}';
-        $json .= ',{"courseId":"'.$coursetwo->id.'","courseName":"'.$coursetwo->fullname.'","courseShortName":"'.$coursetwo->shortname.'","roles":"urn:lti:sysrole:ims\/lis\/Administrator"}';
-        $json .= ',{"courseId":"'.$coursethree->id.'","courseName":"'.$coursethree->fullname.'","courseShortName":"'.$coursethree->shortname.'","roles":"urn:lti:sysrole:ims\/lis\/Administrator"}';
-        $json .= ',{"courseId":"'.$coursefour->id.'","courseName":"'.$coursefour->fullname.'","courseShortName":"'.$coursefour->shortname.'","roles":"urn:lti:sysrole:ims\/lis\/Administrator"}]}';
+        $json = '{"courses":[]}';
 
         $this->assertEquals(base64_encode($json), $result);
     }


### PR DESCRIPTION
Update to add use of new specific capabilities for Kaltura filter and LTI role assignment, rather than repurposing existing core capabilities. Enables full granular control of permissions in cases where the repurposed core capabilities are not suitable for assignment.