### PR TITLE
Fix core unit tests failing

### DIFF
--- a/filter/kaltura/db/install.php
+++ b/filter/kaltura/db/install.php
@@ -25,5 +25,10 @@ function xmldb_filter_kaltura_install() {
     global $CFG;
     require_once("$CFG->libdir/filterlib.php");
 
-    filter_set_global_state('kaltura', TEXTFILTER_ON);
+    // Do not enable the filter when running unit tests because some core
+    // tests expect a specific number of filters enabled.
+    if (!defined('PHPUNIT_TEST') || !PHPUNIT_TEST) {
+        filter_set_global_state('kaltura', TEXTFILTER_ON);
+    }
+
 }


### PR DESCRIPTION
**Description:** This applies the fixes outlined in #394. This fails [this test](https://github.com/moodle/moodle/blob/MOODLE_401_STABLE/course/tests/externallib_test.php#L2800) with the following error message:

```
1) externallib_test::test_get_courses_by_field
Failed asserting that actual size 7 matches expected size 6.

/var/www/site/course/tests/externallib_test.php:2800
/var/www/site/lib/phpunit/classes/advanced_testcase.php:80
```
This proposed fix allows the unit test to be ran successfully