### PR TITLE
Replaces calls to deprecated assertions with supported equivalent.

### DIFF
--- a/local/kaltura/tests/locallib_test.php
+++ b/local/kaltura/tests/locallib_test.php
@@ -716,21 +716,21 @@ class local_kaltura_locallib_testcase extends advanced_testcase {
 
         $result = local_kaltura_format_lti_instance_object($param);
 
-        $this->assertObjectHasAttribute('course', $result);
-        $this->assertObjectHasAttribute('id', $result);
-        $this->assertObjectHasAttribute('name', $result);
-        $this->assertObjectHasAttribute('intro', $result);
-        $this->assertObjectHasAttribute('instructorchoicesendname', $result);
-        $this->assertObjectHasAttribute('instructorchoicesendemailaddr', $result);
-        $this->assertObjectHasAttribute('instructorcustomparameters', $result);
-        $this->assertObjectHasAttribute('instructorchoiceacceptgrades', $result);
-        $this->assertObjectHasAttribute('instructorchoiceallowroster', $result);
-        $this->assertObjectHasAttribute('resourcekey', $result);
-        $this->assertObjectHasAttribute('password', $result);
-        $this->assertObjectHasAttribute('toolurl', $result);
-        $this->assertObjectHasAttribute('securetool', $result);
-        $this->assertObjectHasAttribute('forcessl', $result);
-        $this->assertObjectHasAttribute('cmid', $result);
+        $this->assertObjectHasProperty('course', $result);
+        $this->assertObjectHasProperty('id', $result);
+        $this->assertObjectHasProperty('name', $result);
+        $this->assertObjectHasProperty('intro', $result);
+        $this->assertObjectHasProperty('instructorchoicesendname', $result);
+        $this->assertObjectHasProperty('instructorchoicesendemailaddr', $result);
+        $this->assertObjectHasProperty('instructorcustomparameters', $result);
+        $this->assertObjectHasProperty('instructorchoiceacceptgrades', $result);
+        $this->assertObjectHasProperty('instructorchoiceallowroster', $result);
+        $this->assertObjectHasProperty('resourcekey', $result);
+        $this->assertObjectHasProperty('password', $result);
+        $this->assertObjectHasProperty('toolurl', $result);
+        $this->assertObjectHasProperty('securetool', $result);
+        $this->assertObjectHasProperty('forcessl', $result);
+        $this->assertObjectHasProperty('cmid', $result);
 
         $this->assertEquals(1, $result->course);
         $this->assertEquals(1, $result->id);
@@ -846,21 +846,21 @@ class local_kaltura_locallib_testcase extends advanced_testcase {
         $this->assertTrue($result);
         $record = $DB->get_record('local_kaltura_log', array('module'=> 'mymedia'));
 
-        $this->assertObjectHasAttribute('id', $record);
+        $this->assertObjectHasProperty('id', $record);
 
-        $this->assertObjectHasAttribute('module', $record);
+        $this->assertObjectHasProperty('module', $record);
         $this->assertEquals(KAF_MYMEDIA_MODULE, $record->module);
 
-        $this->assertObjectHasAttribute('type', $record);
+        $this->assertObjectHasProperty('type', $record);
         $this->assertEquals(KALTURA_LOG_REQUEST, $record->type);
 
-        $this->assertObjectHasAttribute('endpoint', $record);
+        $this->assertObjectHasProperty('endpoint', $record);
         $this->assertEquals('http://localhost', $record->endpoint);
 
-        $this->assertObjectHasAttribute('data', $record);
+        $this->assertObjectHasProperty('data', $record);
         $this->assertEquals(serialize($data), $record->data);
 
-        $this->assertObjectHasAttribute('timecreated', $record);
+        $this->assertObjectHasProperty('timecreated', $record);
         $this->assertNotEquals(0, $record);
 
         $result = local_kaltura_log_data(KAF_MEDIAGALLERY_MODULE, 'http://localhost', $data, true);
@@ -868,21 +868,21 @@ class local_kaltura_locallib_testcase extends advanced_testcase {
 
         $record = $DB->get_record('local_kaltura_log', array('module'=> 'coursegallery'));
 
-        $this->assertObjectHasAttribute('id', $record);
+        $this->assertObjectHasProperty('id', $record);
 
-        $this->assertObjectHasAttribute('module', $record);
+        $this->assertObjectHasProperty('module', $record);
         $this->assertEquals(KAF_MEDIAGALLERY_MODULE, $record->module);
 
-        $this->assertObjectHasAttribute('type', $record);
+        $this->assertObjectHasProperty('type', $record);
         $this->assertEquals(KALTURA_LOG_REQUEST, $record->type);
 
-        $this->assertObjectHasAttribute('endpoint', $record);
+        $this->assertObjectHasProperty('endpoint', $record);
         $this->assertEquals('http://localhost', $record->endpoint);
 
-        $this->assertObjectHasAttribute('data', $record);
+        $this->assertObjectHasProperty('data', $record);
         $this->assertEquals(serialize($data), $record->data);
 
-        $this->assertObjectHasAttribute('timecreated', $record);
+        $this->assertObjectHasProperty('timecreated', $record);
         $this->assertNotEquals(0, $record);
     }
 
@@ -905,21 +905,21 @@ class local_kaltura_locallib_testcase extends advanced_testcase {
 
         $record = $DB->get_record('local_kaltura_log', array('module'=> 'phpunit response'));
 
-        $this->assertObjectHasAttribute('id', $record);
+        $this->assertObjectHasProperty('id', $record);
 
-        $this->assertObjectHasAttribute('module', $record);
+        $this->assertObjectHasProperty('module', $record);
         $this->assertEquals('phpunit response', $record->module);
 
-        $this->assertObjectHasAttribute('type', $record);
+        $this->assertObjectHasProperty('type', $record);
         $this->assertEquals(KALTURA_LOG_RESPONSE, $record->type);
 
-        $this->assertObjectHasAttribute('endpoint', $record);
+        $this->assertObjectHasProperty('endpoint', $record);
         $this->assertEquals('http://localhost', $record->endpoint);
 
-        $this->assertObjectHasAttribute('data', $record);
+        $this->assertObjectHasProperty('data', $record);
         $this->assertEquals(serialize($data), $record->data);
 
-        $this->assertObjectHasAttribute('timecreated', $record);
+        $this->assertObjectHasProperty('timecreated', $record);
         $this->assertNotEquals(0, $record);
     }
 

--- a/local/kaltura/tests/migrationlib_test.php
+++ b/local/kaltura/tests/migrationlib_test.php
@@ -44,12 +44,12 @@ class local_kaltura_migrationlib_testcase extends advanced_testcase {
 
         $configsettings = get_config(KALTURA_PLUGIN_NAME);
 
-        $this->assertObjectHasAttribute('migrationstarted', $configsettings);
-        $this->assertObjectHasAttribute('existingcategoryrun', $configsettings);
-        $this->assertObjectHasAttribute('sharedcategoryrun', $configsettings);
-        $this->assertObjectHasAttribute('categoriescreated', $configsettings);
-        $this->assertObjectHasAttribute('entriesmigrated', $configsettings);
-        $this->assertObjectHasAttribute('kafcategoryrootid', $configsettings);
+        $this->assertObjectHasProperty('migrationstarted', $configsettings);
+        $this->assertObjectHasProperty('existingcategoryrun', $configsettings);
+        $this->assertObjectHasProperty('sharedcategoryrun', $configsettings);
+        $this->assertObjectHasProperty('categoriescreated', $configsettings);
+        $this->assertObjectHasProperty('entriesmigrated', $configsettings);
+        $this->assertObjectHasProperty('kafcategoryrootid', $configsettings);
         $this->assertEquals(0, $configsettings->migrationstarted);
         $this->assertEquals(0, $configsettings->existingcategoryrun);
         $this->assertEquals(0, $configsettings->sharedcategoryrun);


### PR DESCRIPTION
PHPUnit 9.6 deprecates these methods.

Please see https://tracker.moodle.org/browse/MDL-81281 for reference.

fixes #440 