### PR TITLE
Kms 33419 moodle same site session cookie

### DIFF
--- a/local/kaltura/service.php
+++ b/local/kaltura/service.php
@@ -56,7 +56,7 @@ $serviceurl = new moodle_url('/local/kaltura/service.php');
 
 // Log the request.
 $enablelogging = get_config(KALTURA_PLUGIN_NAME, 'enable_logging');
-if (!empty($enablelogging)) {
+if (!empty($enablelogging) && isloggedin()) {
     $param = array(
         'url' => $url,
         'width' => $width,

--- a/local/kaltura/service.php
+++ b/local/kaltura/service.php
@@ -23,10 +23,10 @@
  * @copyright  (C) 2014 Remote Learner.net Inc http://www.remote-learner.net
  */
 
+define('NO_MOODLE_COOKIES', true);
+
 require_once(dirname(__FILE__).'/../../config.php');
 require_once($CFG->dirroot.'/local/kaltura/locallib.php');
-
-require_login();
 
 global $PAGE;
 

--- a/local/kaltura/service.php
+++ b/local/kaltura/service.php
@@ -56,7 +56,7 @@ $serviceurl = new moodle_url('/local/kaltura/service.php');
 
 // Log the request.
 $enablelogging = get_config(KALTURA_PLUGIN_NAME, 'enable_logging');
-if (!empty($enablelogging) && isloggedin()) {
+if (!empty($enablelogging)) {
     $param = array(
         'url' => $url,
         'width' => $width,


### PR DESCRIPTION
`service.php` is reached via a (possibly, when there is no KAF alias) cross-origin redirect from KAF, so the Moodle session cookie is not available when it loads.
Rather than relying on `require_login()`, which fails in this context and causes the session cookie to be reissued (and logs the user out of Moodle), we now use `define('NO_MOODLE_COOKIES', true)`, same pattern Moodle uses in https://github.com/moodle/moodle/blob/main/public/mod/lti/service.php#L27
It is safe since the endpoint performs no privileged operations and exposes no sensitive data. It only passes metadata back to the parent Moodle page.
See https://moodle.atlassian.net/browse/MDL-83526 for more info about the reason for this change.