### PR TITLE
KMS-33419 moodle same site session cookie

### DIFF
--- a/local/kaltura/service.php
+++ b/local/kaltura/service.php
@@ -26,9 +26,25 @@
 require_once(dirname(__FILE__).'/../../config.php');
 require_once($CFG->dirroot.'/local/kaltura/locallib.php');
 
-require_login();
+global $PAGE, $_POST, $_SERVER;
 
-global $PAGE;
+$PAGE->set_url(new moodle_url('/local/kaltura/service.php'));
+$PAGE->set_context(context_system::instance());
+$PAGE->set_pagelayout('embedded');
+
+// When KAF POSTs back to this endpoint cross-site, SameSite=Lax causes the moodle session cookie to be dropped.
+// Re-post from the same origin so the browser attaches the session cookie on the second request.
+if (!isloggedin() && empty($_POST['repost'])) {
+    header_remove('Set-Cookie');
+    $output = $PAGE->get_renderer('mod_lti');
+    $page = new \mod_lti\output\repost_crosssite_page($_SERVER['REQUEST_URI'], $_POST);
+    echo $output->header();
+    echo $output->render($page);
+    echo $output->footer();
+    return;
+}
+
+require_login();
 
 
 $url = required_param('url', PARAM_URL);
@@ -89,8 +105,6 @@ $metadata->size = $size;
 
 $metadata = local_kaltura_encode_object_for_storage($metadata);
 
-$PAGE->set_url($serviceurl);
-$PAGE->set_context(context_system::instance());
 $previewltilaunchurl = new moodle_url('/local/kaltura/bsepreview_ltilaunch.php?playurl=' . urlencode($url));
 $params = array(
     'iframeurl' => urlencode($url),
@@ -104,7 +118,6 @@ $params = array(
 );
 
 $PAGE->requires->yui_module('moodle-local_kaltura-ltiservice', 'M.local_kaltura.init', array($params));
-$PAGE->set_pagelayout('embedded');
 
 echo $OUTPUT->header();
 echo $OUTPUT->footer();


### PR DESCRIPTION
`service.php` is reached via a (possibly, when there is no KAF alias) cross-site redirect from KAF, so the Moodle session cookie is not available when it loads (`SameSite=Lax`).
See https://moodle.atlassian.net/browse/MDL-83526 for more info about the reason for this change.
See https://moodle.atlassian.net/browse/MDL-88721?focusedCommentId=1149055 for more info about the fix.